### PR TITLE
Fix enterprise-dashboard-collections next page link

### DIFF
--- a/source/docs/0.20/enterprise-dashboard-collections.md
+++ b/source/docs/0.20/enterprise-dashboard-collections.md
@@ -3,8 +3,8 @@ version: 0.20
 category: "Collections"
 title: "Collections"
 next:
-  url: "enterprise-dashboard-overview-dashboard"
-  text: "Enterprise Dashboard Overview Dashboard"
+  url: "enterprise-dashboard-hud"
+  text: "Enterprise Dashboard HUD"
 ---
 
 ## Collections

--- a/source/docs/0.21/enterprise-dashboard-collections.md
+++ b/source/docs/0.21/enterprise-dashboard-collections.md
@@ -3,8 +3,8 @@ version: 0.21
 category: "Collections"
 title: "Collections"
 next:
-  url: "enterprise-dashboard-overview-dashboard"
-  text: "Enterprise Dashboard Overview Dashboard"
+  url: "enterprise-dashboard-hud"
+  text: "Enterprise Dashboard HUD"
 ---
 
 ## Collections


### PR DESCRIPTION
This PR points the next page to HUD instead of enterprise-dashboard-overview-dashboard

From the index on the left hand side I got that the page after Collections is HUD
That said, the link at the bottom of the Collections page points to
https://sensuapp.org/docs/0.20/enterprise-dashboard-overview-dashboard .
Yet that pages doesn't exist.